### PR TITLE
Mk3 lcd buffer leptun

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -7639,12 +7639,7 @@ Sigma_Exit:
 	}
 	break;
 	case 998:
-		for (int i = 0; i < LCD_HEIGHT; i++){
-			for (int j = 0; j < LCD_WIDTH; j++){
-				MYSERIAL.print(vga_get_char(j, i));
-			}
-			MYSERIAL.print("\n");
-		}
+		lcd_debug();
 		break;
 
 

--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -419,12 +419,16 @@ void lcd_set_cursor(uint8_t col, uint8_t row) //vga
 static void lcd_set_cursor_hardware(uint8_t col, uint8_t row, bool nibbleLess = 0) //lcd
 {
 	int row_offsets[] = { 0x00, 0x40, 0x14, 0x54 };
-#ifndef LCD_8BIT
+#ifdef LCD_8BIT
 	if (nibbleLess)
-#endif
-	lcd_send(LCD_SETDDRAMADDR | (col + row_offsets[row]), LOW, 0);
-#ifndef LCD_8BIT
-	lcd_send((lcd_status & 0x04)?(LCD_SETDDRAMADDR | (col + row_offsets[row])):((LCD_SETDDRAMADDR | (col + row_offsets[row])) << 4), LOW | LCD_HALF_FLAG, 0);
+		lcd_send(LCD_SETDDRAMADDR | (col + row_offsets[row]), LOW, 100);
+	else
+		lcd_send(LCD_SETDDRAMADDR | (col + row_offsets[row]), LOW, 0);
+#else
+	if (nibbleLess)
+		lcd_send(LCD_SETDDRAMADDR | (col + row_offsets[row]), LOW, 100);
+	else
+		lcd_send((lcd_status & 0x04)?(LCD_SETDDRAMADDR | (col + row_offsets[row])):((LCD_SETDDRAMADDR | (col + row_offsets[row])) << 4), LOW | LCD_HALF_FLAG, 0);
 #endif
 }
 
@@ -1129,10 +1133,10 @@ void lcd_set_custom_characters(void)
 
 void lcd_set_custom_characters_arrows(void)
 {
-	lcd_timer_disable();
+	LcdTimerDisabler_START;
 	lcd_createChar_P(1, lcd_chardata_arrdown);
 	lcd_set_cursor_hardware(lcd_curpos % LCD_WIDTH, lcd_curpos / LCD_WIDTH, true);
-	lcd_timer_enable();
+	LcdTimerDisabler_END;
 }
 
 const uint8_t lcd_chardata_arr2down[8] PROGMEM = {
@@ -1156,18 +1160,18 @@ const uint8_t lcd_chardata_confirm[8] PROGMEM = {
 
 void lcd_set_custom_characters_nextpage(void)
 {
-	lcd_timer_disable();
+	LcdTimerDisabler_START;
 	lcd_createChar_P(1, lcd_chardata_arr2down);
 	lcd_createChar_P(2, lcd_chardata_confirm);
 	lcd_set_cursor_hardware(lcd_curpos % LCD_WIDTH, lcd_curpos / LCD_WIDTH, true);
-	lcd_timer_enable();
+	LcdTimerDisabler_END;
 }
 
 void lcd_set_custom_characters_degree(void)
 {
-	lcd_timer_disable();
+	LcdTimerDisabler_START;
 	lcd_createChar_P(1, lcd_chardata_degree);
 	lcd_set_cursor_hardware(lcd_curpos % LCD_WIDTH, lcd_curpos / LCD_WIDTH, true);
-	lcd_timer_enable();
+	LcdTimerDisabler_END;
 }
 

--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -320,7 +320,7 @@ static void vga_init(void) //vga
 	TCCRxA &= ~(3<<COM3A0);
 	TCCRxA &= ~(3<<COM3B0);
 	TCCRxA &= ~(3<<COM3C0);
-	OCRxA = (LCD_DEFAULT_DELAY* 6 *(F_CPU/1000000/8)) - 1; //set timer TOP value with an 8x prescaler
+	OCRxA = (LCD_DEFAULT_DELAY* 4 *(F_CPU/1000000/8)) - 1; //set timer TOP value with an 8x prescaler
 	
 	lcd_status &= ~0x0f;
 	lcd_status |= 0x04;

--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -320,7 +320,7 @@ static void vga_init(void) //vga
 	TCCRxA &= ~(3<<COM3A0);
 	TCCRxA &= ~(3<<COM3B0);
 	TCCRxA &= ~(3<<COM3C0);
-	OCRxA = (LCD_DEFAULT_DELAY* 4 *(F_CPU/1000000/8)) - 1; //set timer TOP value with an 8x prescaler
+	OCRxA = (LCD_DEFAULT_DELAY * 2 * (F_CPU/1000000/8)) - 1; //set timer TOP value with an 8x prescaler. The push speed is slowed down a bit.
 	
 	lcd_status &= ~0x0f;
 	lcd_status |= 0x04;

--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -246,6 +246,7 @@ static void lcd_write(uint8_t value) //vga
 		vga_linefeed();
 		return;
 	}
+	if (vga_currcol == LCD_WIDTH) vga_linefeed();
 	#ifdef VT100
 	if (lcd_escape[0] || (value == 0x1b)){
 		lcd_escape_write(value);
@@ -259,7 +260,6 @@ static void lcd_write(uint8_t value) //vga
 		if (!(lcd_status & 0x01)) lcd_timer_enable();
 	}
 	vga_currcol++;
-	if (vga_currcol == LCD_WIDTH) vga_linefeed();
 }
 
 static void lcd_clear_hardware(void);

--- a/Firmware/lcd.cpp
+++ b/Firmware/lcd.cpp
@@ -82,7 +82,7 @@ uint8_t lcd_displaymode = 0;
 #endif
 
 volatile uint8_t lcd_curpos;
-//xbbbbaaa: cursor position from 0 to (LCD_WIDTH * LCD_HEIGHT)
+//xbbbbaaa: cursor position from 0 to (LCD_WIDTH * LCD_HEIGHT)-1
 //bbbb: index of the cluster in vga_map to search. From 0 to VGA_MAP_SIZE-1
 //aaa: Rshift value for the bit to search. From 0 to 7
 //x: unused. Leave it clear.
@@ -96,10 +96,10 @@ volatile uint8_t vga_map[VGA_MAP_SIZE]; //bitmap for changes on the display. Ind
 // 3  77778888888899999999
 
 volatile uint8_t lcd_status = 0;
-//xxxxxcba
+//xxxxdcba
 //a: timer enabled status
 //b: bit is set only if the timer is enabled and is used in the ISR to disable itself after required time has passed to send commands to it. ie: lcd_refresh();
-//c: nibble
+//c: nibble: it is used for the 4bit lcd interface to keep track of what part of the byte has to be sent on the next ISR
 //d: current command type. 1=lcd_set_cursor (jump); 0=character. Used by the ISR for the second nibble and also to decide whether a jump command is necessary (eg. next character is on the next line).
 
 //vga

--- a/Firmware/lcd.h
+++ b/Firmware/lcd.h
@@ -22,8 +22,6 @@ extern void lcd_timer_disable(void);
 
 extern void lcd_refresh(void);
 
-extern void lcd_refresh_noclear(void);
-
 extern void lcd_clear(void);
 
 extern void lcd_home(void);
@@ -94,8 +92,6 @@ extern uint8_t lcd_button_pressed;
 
 extern uint8_t lcd_update_enabled;
 
-extern uint8_t lcd_timer_enabled;
-
 extern LongTimer lcd_timeoutToStatus;
 
 extern uint32_t lcd_next_update_millis;
@@ -146,23 +142,11 @@ private:
     bool m_updateEnabled;
 };
 
+#define LcdTimerDisabler_START bool oldTimerStatus = lcd_timer_status & 0x01; lcd_timer_disable();
+#define LcdTimerDisabler_END if (oldTimerStatus) lcd_timer_enable();
 
-class LcdTimerDisabler
-{
-public:
-	LcdTimerDisabler(): m_timerEnabled(lcd_timer_enabled)
-	{
-		lcd_timer_disable();
-	}
-	~LcdTimerDisabler()
-	{
-		if (m_timerEnabled)
-		lcd_timer_enable();
-	}
+extern void lcd_debug();
 
-private:
-	bool m_timerEnabled;
-};
 
 ////////////////////////////////////
 // Setup button and encode mappings for each panel (into 'lcd_buttons' variable

--- a/Firmware/lcd.h
+++ b/Firmware/lcd.h
@@ -142,7 +142,7 @@ private:
     bool m_updateEnabled;
 };
 
-#define LcdTimerDisabler_START bool oldTimerStatus = lcd_timer_status & 0x01; lcd_timer_disable();
+#define LcdTimerDisabler_START bool oldTimerStatus = lcd_status & 0x01; lcd_timer_disable();
 #define LcdTimerDisabler_END if (oldTimerStatus) lcd_timer_enable();
 
 extern void lcd_debug();

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -971,15 +971,10 @@ static void lcd_status_screen()
 	if (lcd_draw_update)
 	{
 		ReInitLCD++;
-		if (ReInitLCD == 30)
+		if (ReInitLCD == 15)
 		{
 			lcd_refresh(); // to maybe revive the LCD if static electricity killed it.
-			ReInitLCD = 0 ;
-		}
-		else
-		{
-			if ((ReInitLCD % 10) == 0)
-				lcd_refresh_noclear(); //to maybe revive the LCD if static electricity killed it.
+			ReInitLCD = 0;
 		}
 
 		lcdui_print_status_screen();
@@ -1037,7 +1032,6 @@ static void lcd_status_screen()
 	{
 		menu_depth = 0; //redundant, as already done in lcd_return_to_status(), just to be sure
 		menu_submenu(lcd_main_menu);
-		lcd_refresh(); // to maybe revive the LCD if static electricity killed it.
 	}
 
 #ifdef ULTIPANEL_FEEDMULTIPLY
@@ -1648,7 +1642,6 @@ void lcd_commands()
 
 void lcd_return_to_status()
 {
-	lcd_refresh(); // to maybe revive the LCD if static electricity killed it.
 	menu_goto(lcd_status_screen, 0, false, true);
 	menu_depth = 0;
      eFilamentAction=FilamentAction::None; // i.e. non-autoLoad
@@ -8368,7 +8361,6 @@ void ultralcd_init()
 
     }
 	lcd_init();
-	lcd_refresh();
 	lcd_longpress_func = menu_lcd_longpress_func;
 	lcd_charsetup_func = menu_lcd_charsetup_func;
 	lcd_lcdupdate_func = menu_lcd_lcdupdate_func;
@@ -8552,7 +8544,6 @@ void menu_lcd_lcdupdate_func(void)
 	{
 		lcd_draw_update = 2;
 		lcd_oldcardstatus = IS_SD_INSERTED;
-		lcd_refresh(); // to maybe revive the LCD if static electricity killed it.
 		if (lcd_oldcardstatus)
 		{
 			card.initsd();

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -8361,6 +8361,7 @@ void ultralcd_init()
 
     }
 	lcd_init();
+	lcd_refresh();
 	lcd_longpress_func = menu_lcd_longpress_func;
 	lcd_charsetup_func = menu_lcd_charsetup_func;
 	lcd_lcdupdate_func = menu_lcd_lcdupdate_func;


### PR DESCRIPTION
This PR is my approach to the LCD Buffer implementation (#2064).
@DRracer @mkbel @wavexx @3d-gussner @maximlevitsky @GurliGebis . I hope everyone interested has been included.
I've come to a point where it's actually usable. There are some regressions, but nothing that can't be fixed.
I've tried documenting my changes as well as I could. I'll also explain them here:


Just like the base LCD Buffer branch, we have a uint8_t 2-dimensional array that holds the entire LCD data inside 
`uint8_t vga[LCD_WIDTH][LCD_HEIGHT]; //vga buffer.`

Alongside it we also have another smaller array that holds a bitmap of all changes that occur on the lcd. This way if a character changes, only that has to be changed. It is also of type uint8_t since it's the most efficient data type for the 8bit avr.
```
volatile uint8_t vga_map[VGA_MAP_SIZE]; //bitmap for changes on the display. Individual bits are set when lcd_write() is used
//    01234567890123456789
  
// 0  00000000111111112222
// 1  22223333333344444444
// 2  55555555666666667777
// 3  77778888888899999999
```

With this implementation there are two "cursors" we need to keep track of: the VGA cursor that is used for putting data into the buffer (it is split in two variables for the corresponding axis; could be merged into one if needed)
```
uint8_t vga_currline; //these two are used for puting data into the vga buffer.
uint8_t vga_currcol;
```

And another cursor that is the current position and sometimes also target position for the lcd itself. It's used by the ISR to manage the lcd. It is also of type uint8_t, although only 7 bits are needed for this.
```
volatile uint8_t lcd_curpos;
//xbbbbaaa: Can be interpreted as cursor position from 0 to (LCD_WIDTH * LCD_HEIGHT)-1
//bbbb: index of the cluster in vga_map to search. From 0 to VGA_MAP_SIZE-1
//aaa: Rshift value for the bit to search. From 0 to 7
//x: unused. Leave it clear.
```

Some bools were needed to keep track of different tasks. In order to memory they've been compressed into one uint8_t variable:
```
volatile uint8_t lcd_status = 0;
//xxxxdcba
//a: timer enabled status
//b: bit is set only if the timer is enabled and is used in the ISR to disable itself after required time has passed to send commands to it. ie: lcd_refresh();
//c: nibble: it is used for the 4bit lcd interface to keep track of what part of the byte has to be sent on the next ISR
//d: current command type. 1=lcd_set_cursor (jump); 0=character. Used by the ISR for the second nibble and also to decide whether a jump command is necessary (eg. next character is on the next line).
```

Now for the ISR part:
It first checks whether the code is waiting for it to be disabled. This can only be done when the second half of the character has been sent to the lcd (nibble is 1 when the ISR gets triggered) as to avoid the nibble getting out of sync with the lcd and sending corrupt data.

Then it figures out whether the lcd_curchar needs to be written or not or if there is no need to print any data (in which case it disables itself). This part of the isr can be drastically improved.

Then it figures out if it can print a new character, jump to the desired character or disable itself (as noted earlier).

The last part of the ISR is for continuing the second half of the data transfer and prepare it for the next cycle.

For debugging purposes you can use M998 to get all the variables printed. A more drastic approach is to enable LCD_DEBUG define which prints to the serial every single command sent to the lcd and ISR steps. It should be used with care since it prints to serial from ISR, something that should be avoided.

Also please note there are some problems while printing for now. I'll try to fix them later. For now I'm waiting for some feedback.