### PR TITLE
Update ALTFAN eeprom documentation

### DIFF
--- a/Firmware/eeprom.h
+++ b/Firmware/eeprom.h
@@ -359,8 +359,12 @@ static_assert(sizeof(Sheets) == EEPROM_SHEETS_SIZEOF, "Sizeof(Sheets) is not EEP
 | ^					| ^			| ^										| 00h 0			| ^						| LCD backlight mode: __Dim__						| ^				| ^
 | 0x0D30 3376		| uint16	| EEPROM_BACKLIGHT_TIMEOUT				| 01 00 - ff ff | 0a 00h 65535			| LCD backlight timeout: __10__ seconds				| LCD menu		| D3 Ax0d30 C2
 | 0x0D2C 3372		| float		| EEPROM_UVLO_LA_K						| ???			| ff ff ff ffh			| Power panic saved Linear Advanced K value			| ???			| D3 Ax0d2c C4
-| 0x0D2B 3371		| uint8		| EEPROM_ALTFAN_OVERRIDE				| 0-1			| 00h 0					| ALTFAN override									| LCD menu		| D3 Ax0d2b C1
-| 0x0D2A 3370		| uint8		| EEPROM_EXPERIMENTAL_VISIBILITY		| 0-1			| 00h 0					| Experimental menu visibility						| LCD menu		| D3 Ax0d2a C1
+| 0x0D2B 3371		| uint8		| EEPROM_ALTFAN_OVERRIDE				| ffh 255		| ffh 255				| ALTFAN override unknown state						| LCD menu		| D3 Ax0d2b C1
+| ^					| ^			| ^										| 00h 0			| ^						| ALTFAN override deactivated						| ^				| ^
+| ^					| ^			| ^										| 01h 1			| ^						| ALTFAN override activated 						| ^				| ^
+| 0x0D2A 3370		| uint8		| EEPROM_EXPERIMENTAL_VISIBILITY		| ffh 255		| ffh 255				| Experimental menu visibility unknown state		| LCD menu		| D3 Ax0d2a C1
+| ^					| ^			| ^										| 00h 0			| ^						| Experimental menu visibility hidden				| ^				| ^
+| ^					| ^			| ^										| 01h 1			| ^						| Experimental menu visibility visible				| ^				| ^
 
   
 | Address begin		| Bit/Type 	| Name 									| Valid values	| Default/FactoryReset	| Description 										| Gcode/Function| Debug code


### PR DESCRIPTION
EEPROM_ALTFAN_OVERRIDE and EEPROM_EXPERIMENTAL_VISIBILITY are compared to 0xFF in the code that's why I keep the uint8.